### PR TITLE
phoneAppOnly API

### DIFF
--- a/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
+++ b/android/src/main/java/com/burnweb/rnsendintent/RNSendIntentModule.java
@@ -242,10 +242,13 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void sendPhoneCall(String phoneNumberString) {
+    public void sendPhoneCall(String phoneNumberString, Boolean phoneAppOnly) {
       //Needs permission "android.permission.CALL_PHONE"
       Intent sendIntent = new Intent(Intent.ACTION_CALL, Uri.parse("tel:" + phoneNumberString.replaceAll("#", "%23").trim()));
       sendIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      if (phoneAppOnly == true) {
+          sendIntent.setPackage("com.android.server.telecom");
+      }
 
       //Check that an app exists to receive the intent
       if (sendIntent.resolveActivity(this.reactContext.getPackageManager()) != null) {
@@ -260,9 +263,12 @@ public class RNSendIntentModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void sendPhoneDial(String phoneNumberString) {
+    public void sendPhoneDial(String phoneNumberString, Boolean phoneAppOnly) {
       Intent sendIntent = new Intent(Intent.ACTION_DIAL, Uri.parse("tel:" + phoneNumberString.trim()));
       sendIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      if (phoneAppOnly == true) {
+          sendIntent.setPackage("com.android.server.telecom");
+      }
 
       //Check that an app exists to receive the intent
       if (sendIntent.resolveActivity(this.reactContext.getPackageManager()) != null) {

--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ var SendIntentAndroid = {
             RNSendIntentAndroid.sendText(config.text, config.type || "text/plain");
         }
     },
-    sendPhoneCall(phoneNumber) {
-        RNSendIntentAndroid.sendPhoneCall(phoneNumber);
+    sendPhoneCall(phoneNumber, dialOnly = false) {
+        RNSendIntentAndroid.sendPhoneCall(phoneNumber, dialOnly);
     },
     sendPhoneDial(phoneNumber) {
         RNSendIntentAndroid.sendPhoneDial(phoneNumber);

--- a/index.js
+++ b/index.js
@@ -15,11 +15,11 @@ var SendIntentAndroid = {
             RNSendIntentAndroid.sendText(config.text, config.type || "text/plain");
         }
     },
-    sendPhoneCall(phoneNumber, dialOnly = false) {
-        RNSendIntentAndroid.sendPhoneCall(phoneNumber, dialOnly);
+    sendPhoneCall(phoneNumber, phoneAppOnly = false) {
+        RNSendIntentAndroid.sendPhoneCall(phoneNumber, phoneAppOnly);
     },
-    sendPhoneDial(phoneNumber) {
-        RNSendIntentAndroid.sendPhoneDial(phoneNumber);
+    sendPhoneDial(phoneNumber, phoneAppOnly = false) {
+        RNSendIntentAndroid.sendPhoneDial(phoneNumber, phoneAppOnly);
     },
     sendSms(phoneNumber, body) {
         RNSendIntentAndroid.sendSms(phoneNumber, body || null);


### PR DESCRIPTION
Sets only the OS phone app to handle calls with the option to use any other app.